### PR TITLE
Handle Brave Browser getImageData Protection

### DIFF
--- a/center.js
+++ b/center.js
@@ -149,7 +149,7 @@ function centerjs(options) {
         // let b_value = data[r_index + 2];
         // let a_value = data[r_index + 3];
 
-        if (r_value > 0) {
+        if (r_value === 255) {
           if (!textTop) {
             textTop = y;
           }
@@ -173,7 +173,7 @@ function centerjs(options) {
         let r_index = 4 * (canvas.width * y + x);
         let r_value = data[r_index];
 
-        if (r_value > 0) {
+        if (r_value === 255) {
           if (!textLeft) {
             textLeft = x;
           }


### PR DESCRIPTION
Brave Browser manipulates RGB values returned by `CanvasRenderingContext2D.getImageData()` to prevent fingerprinting, but this ends up breaking text centering.

When RGB values flip from 0 to 1 measurement of the text width and height are incorrect. A more strict check of the RGB values prevents the incorrect measurement.

<img width="832" alt="Screen Shot 2021-04-03 at 11 46 29 AM" src="https://user-images.githubusercontent.com/4601530/113485366-b643a080-9472-11eb-9028-9bf5a558c98a.png">

<img width="832" alt="Screen Shot 2021-04-03 at 11 46 45 AM" src="https://user-images.githubusercontent.com/4601530/113485748-d4aa9b80-9474-11eb-8e13-55b3606633cc.png">
